### PR TITLE
fix ai response line overflow

### DIFF
--- a/ipyai/core.py
+++ b/ipyai/core.py
@@ -140,7 +140,7 @@ async def _astream_to_live_markdown(chunks, out, code_theme: str, console_cls=Co
             first = chunk
             break
     if first is None: return ""
-    console = console_cls(file=out, force_terminal=True, soft_wrap=True)
+    console = console_cls(file=out, force_terminal=True)
     text = first
     with live_cls(_markdown_renderable(compact_tool_display(text), code_theme, markdown_cls), console=console,
         auto_refresh=False, transient=False) as live:


### PR DESCRIPTION
This PR makes sure the AI response can be fully read on screen. Tested in and outside of tmux.

Here's a screenshot w before and after:

<img width="1512" height="387" alt="image" src="https://github.com/user-attachments/assets/298da204-ce14-43ea-8020-5552d69b3749" />
