### PR TITLE
Fix unawaited line magic

### DIFF
--- a/ipyai/core.py
+++ b/ipyai/core.py
@@ -9,7 +9,7 @@ from fastcore.xdg import xdg_config_home
 from fastcore.xtras import frontmatter
 from IPython import get_ipython
 from IPython.core.inputtransformer2 import leading_empty_lines
-from IPython.core.magic import Magics, line_cell_magic, magics_class
+from IPython.core.magic import Magics, cell_magic, line_magic, magics_class
 from IPython.core.ultratb import SyntaxTB
 from lisette.core import AsyncChat,AsyncStreamFormatter,FullResponse,contents
 from rich.console import Console
@@ -568,9 +568,11 @@ class AIMagics(Magics):
         super().__init__(shell)
         self.ext = ext
 
-    @line_cell_magic("ipyai")
-    async def ipyai(self, line: str="", cell: str | None=None):
-        if cell is None: return self.ext.handle_line(line)
+    @line_magic("ipyai")
+    def ipyai_line(self, line: str=""): return self.ext.handle_line(line)
+
+    @cell_magic("ipyai")
+    async def ipyai_cell(self, line: str="", cell: str | None=None):
         await self.ext._run_prompt(cell)
 
 


### PR DESCRIPTION
`%ipyai` and `%ipyai <subcommand>` (e.g. `sessions`, `reset`, `save`) returned a coroutine object instead of executing, because the magic was declared `async def` but IPython's `run_line_magic` doesn't auto-await async magics. The cell magic path (`%%ipyai` / `.` prompts) worked because `transform_dots` generates a top-level `run_cell_magic()` call, which IPython's `run_cell_async` does auto-await.

```
In [46]: %ipyai
Out[46]: <coroutine object AIMagics.ipyai at 0x147be4ad0>
```

**Fix:** Change the magic from `async def` to `def`, using the existing sync wrapper `run_prompt()` (which calls `shell.loop_runner` internally) instead of directly awaiting `_run_prompt()`

**Tested**

```
In [38]: %ipyai
self.model='claude-sonnet-4-6'
self.completion_model='claude-haiku-4-5-20251001'
self.think='l'
self.search='l'
self.code_theme='monokai'
self.log_exact=False
CONFIG_PATH=Path('/Users/keremturgutlu/.config/ipyai/config.json')
SYSP_PATH=Path('/Users/keremturgutlu/.config/ipyai/sysp.txt')
STARTUP_PATH=Path('/Users/keremturgutlu/.config/ipyai/startup.ipynb')
LOG_PATH=Path('/Users/keremturgutlu/.config/ipyai/exact-log.jsonl')

In [39]: %ipyai sessions
    ID  Start                  Cmds  Last prompt
 26461  2026-03-23 13:10:37      35

In [40]: %ipyai model
self.model='claude-sonnet-4-6'

In [41]: %ipyai model claude-haiku-4-5-20251001
self.model='claude-haiku-4-5-20251001'

In [42]: %ipyai model
self.model='claude-haiku-4-5-20251001'

In [43]: %ipyai reset
Deleted 0 AI prompts from session 26461.

In [44]: .hello
Hello! 👋 I'm here to help you with Python code, data analysis, file manipulation, shell commands, and more.

Feel free to:

 • Write and execute Python code
 • Run shell commands
 • Work with files and text
 • Ask questions about code or data
 • Start prompts with a period (.) to get AI assistance

What would you like to work on?

In [45]: %ipyai save
Saved 0 code cells and 1 prompts to /Users/keremturgutlu/.config/ipyai/startup.ipynb.

In [52]: .&`foo` call the tool
Sure! Let me call it:

 • ⏳ foo() ⏳

🔧 foo()→'bar' => bar

The foo() function returned 'bar' — exactly as defined! 🎉

In [53]: %ipyai call the tool again

 • ⏳ foo() ⏳

🔧 foo()→'bar' => bar

Called it again — still returns 'bar'! 😄
```